### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
         "@vitejs/plugin-vue": "^2.3.3",
         "autoprefixer": "^10.4.7",
         "axios": "^0.25",
-        "laravel-vite-plugin": "^0.2.4",
+        "laravel-vite-plugin": "^0.2.2",
         "lodash": "^4.17.19",
         "postcss": "^8.4.14",
         "qrcode": "^1.5.0",
         "tailwindcss": "^3.0.24",
-        "vite": "^2.9.13"
+        "vite": "^2.9.12"
     },
     "dependencies": {
         "@heroicons/vue": "^1.0.6",
@@ -24,6 +24,7 @@
         "@inertiajs/progress": "^0.2.7",
         "jspdf": "^2.5.1",
         "moment": "^2.29.3",
-        "vue": "^3.2.37"
+        "vue": "^3.2.37",
+        "@vitejs/plugin-vue": "^2.3.3"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,19 +1,11 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [
         laravel([
+            'resources/css/app.css',
             'resources/js/app.js',
         ]),
-        vue({
-            template: {
-                transformAssetUrls: {
-                    base: null,
-                    includeAbsolute: false,
-                },
-            },
-        }),
     ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-65173` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
